### PR TITLE
Remove default initialization for converted types

### DIFF
--- a/uController.CodeGeneration/CodeGenerator.cs
+++ b/uController.CodeGeneration/CodeGenerator.cs
@@ -253,7 +253,7 @@ namespace uController.CodeGeneration
             else
             {
                 WriteLine($"var {sourceName}Value = {sourceExpression}[\"{key}\"]" + (nullable ? "?.ToString();" : ".ToString();"));
-                WriteLine($"{S(type)} {sourceName} = default;");
+                WriteLine($"{S(type)} {sourceName};");
 
                 // TODO: Handle cases where TryParse isn't available
                 // type = Unwrap(type) ?? type;
@@ -276,6 +276,13 @@ namespace uController.CodeGeneration
                     WriteLine($"{sourceName} = {sourceName}Temp;");
                     Unindent();
                     WriteLine("}");
+                    WriteLine("else");
+                    WriteLine("{");
+                    Indent();
+                    WriteLine($"{sourceName} = default;");
+                    Unindent();
+                    WriteLine("}");
+
                 }
             }
         }


### PR DESCRIPTION
This change would remove the default initialization before `TryParse` 

**Old Code**
```
System.Int32 status = default;
if (statusValue == null || !System.Int32.TryParse(statusValue, out status))
{
    status = default;
}
        
System.Nullable<System.Int32> page = default;
if (pageValue != null && System.Int32.TryParse(pageValue, out var pageTemp))
{
    page = pageTemp;
}
```

**New Code**
```
System.Int32 status;
if (statusValue == null || !System.Int32.TryParse(statusValue, out status))
{
    status = default;
}
        
System.Nullable<System.Int32> page;
if (pageValue != null && System.Int32.TryParse(pageValue, out var pageTemp))
{
    page = pageTemp;
}
else
{
    page = default;
}
```